### PR TITLE
avoid re-making casts every time script is run

### DIFF
--- a/CTD_Chipod/mfiles/MakeCasts_CTDchipod_function.m
+++ b/CTD_Chipod/mfiles/MakeCasts_CTDchipod_function.m
@@ -205,9 +205,7 @@ for icast=1:length(CTD_list)
         try
             
             %~~ Load chipod data
-            if  1 %~exist(processed_file,'file')
-                %load(processed_file)
-                % else
+            if ~exist(fullfile(savedir_cal,[castStr '_' whSN '_downcast.mat']),'file')
                 disp('loading chipod data')
                 
                 % Find and load chipod data for this time range
@@ -391,13 +389,17 @@ for icast=1:length(CTD_list)
                     fprintf(fileID,' No chi file found ');
                     %##
                     proc_info.(whSN).IsChiData(icast)=0;
+
+                    delete(fullfile(chi_fig_path_specific,[whSN '_Cast_' castStr '_Fig0_RawCTD.png'])); % delete the CTD figure
                 end % if we have good chipod data for this profile
                 
             else
-                disp('this file already processed')
-                %##
+% %                 load(processed_file)
+%                 disp('this file already processed')
+%                 %##
                 fprintf(fileID,' file already exists, skipping ');
-                %##
+                continue;
+%                 %##
             end % already processed
             
         catch

--- a/CTD_Chipod/mfiles/do_chi_calc_ctd_chipod.m
+++ b/CTD_Chipod/mfiles/do_chi_calc_ctd_chipod.m
@@ -145,10 +145,19 @@ for iSN = 1:length(ChiInfo.SNs)
                     castfile = Flist(icast).name;
                     id1 = strfind(castfile,['_' whSN]);
                     castStr = castfile(1:id1-1);
+
                     %fname=fullfile(savedir_cal,[castStr '_' whSN '_' castdir 'cast.mat']);
                     fname = fullfile(savedir_cal,castfile) ;
                     load(fname)
                     %---
+
+                    chi_proc_path_avg = fullfile(chi_proc_path_specific,'avg',...
+                        ['zsm' num2str(Params.z_smooth) 'm_fmax' num2str(Params.fmax) 'Hz_respcorr' num2str(Params.resp_corr) '_fc_' num2str(Params.fc) 'hz_gamma' num2str(Params.gamma*100)] ) ;
+                    processed_file=fullfile(chi_proc_path_avg,['avg_' castStr '_' C.castdir 'cast_' whSN '_' whsens '.mat']);
+                    if exist(processed_file,'file')
+                        disp(['avg_' castStr '_' C.castdir 'cast_' whSN '_' whsens ' already processed, skipping...'])
+                        continue;
+                    end
                     
                     clear TP ctd
                     TP = C.([whsens 'P']);


### PR DESCRIPTION
This pull request changes [CTD_Chipod/mfiles/MakeCasts_CTDchipod_function.m](https://github.com/OceanMixingGroup/mixingsoftware/compare/master...PovlAbrahamsen:mixingsoftware:processing?expand=1#diff-119a62787561e2f60551ee07e80994f1fca8db4d35f3872385988525c10a554c) to avoid re-processing every cast each time the script is run. Also, if there is no chi-pod data, the raw CTD figure is removed from the directory.